### PR TITLE
Add media attachments support across chat

### DIFF
--- a/event_handlers.py
+++ b/event_handlers.py
@@ -8,7 +8,17 @@ from flask import session
 from flask_socketio import emit, join_room, leave_room
 
 from achievements import apply_progress
-from models import BlockedWord, GroupMembership, GroupMessage, Message, User, db
+from models import (
+    BlockedWord,
+    GroupMembership,
+    GroupMessage,
+    GroupMessageAttachment,
+    MediaUploadToken,
+    Message,
+    MessageAttachment,
+    User,
+    db,
+)
 
 
 def register_event_handlers(socketio, app):
@@ -76,6 +86,7 @@ def register_event_handlers(socketio, app):
             "recipient": recipient_db.username,
             "message": message,
             "timestamp": new_message.timestamp.isoformat(),
+            "attachments": [],
         }
         recipient_room = f"user_{recipient_db.id}"
         sender_room = f"user_{session['user_id']}"
@@ -158,8 +169,191 @@ def register_event_handlers(socketio, app):
             "alias": membership.alias,
             "message": message,
             "timestamp": group_message.timestamp.isoformat(),
+            "attachments": [],
         }
         emit("receive_group_message", payload, room=f"group_{group_id}")
+
+        if sender:
+            socketio.emit(
+                "progress_update",
+                {"xp": sender.xp, "level": sender.level, "badge": sender.badge},
+                room=f"user_{sender.id}",
+            )
+
+    @socketio.on("send_media_message")
+    def handle_send_media_message(data):
+        """Handle sending messages with media attachments."""
+
+        if "user_id" not in session:
+            emit("error", {"error": "You must be logged in to send messages!"})
+            return
+
+        upload_token_value = (data or {}).get("upload_token")
+        if not upload_token_value:
+            emit("error", {"error": "Missing media upload token."})
+            return
+
+        upload_token = MediaUploadToken.query.filter_by(
+            token=upload_token_value, user_id=session["user_id"]
+        ).first()
+        if not upload_token or upload_token.is_consumed or upload_token.is_expired:
+            emit("error", {"error": "Media token is invalid or expired."})
+            return
+
+        caption = (data.get("caption") or "").strip()
+        blocked_word = None
+        if caption:
+            blocked_word = next(
+                (
+                    entry
+                    for entry in BlockedWord.query.all()
+                    if entry.word and entry.word.lower() in caption.lower()
+                ),
+                None,
+            )
+        if blocked_word:
+            emit("error", {"error": "Your caption contains blocked language."})
+            return
+
+        media_payload = {
+            "media_type": upload_token.media_type,
+            "storage_path": upload_token.storage_path,
+            "duration_seconds": upload_token.duration_seconds,
+            "mime_type": upload_token.mime_type,
+        }
+
+        sender = User.query.get(session["user_id"])
+        chat_type = (data.get("chat_type") or "direct").lower()
+
+        if chat_type == "group":
+            group_id = data.get("group_id")
+            alias = data.get("alias")
+            if not group_id:
+                emit("error", {"error": "Group is required for media message."})
+                return
+
+            membership = GroupMembership.query.filter_by(
+                group_id=group_id, user_id=session["user_id"]
+            ).first()
+            if not membership:
+                emit("error", {"error": "You are not a member of this hidden group."})
+                return
+            if alias != membership.alias:
+                emit("error", {"error": "Alias mismatch detected."})
+                return
+
+            group = membership.group
+            if group.expire_at and group.expire_at < datetime.now(timezone.utc):
+                db.session.delete(group)
+                db.session.commit()
+                emit("error", {"error": "This hidden group has expired."})
+                return
+
+            group_message = GroupMessage(
+                group_id=group_id,
+                membership_id=membership.id,
+                alias=membership.alias,
+                text=caption,
+                timestamp=datetime.now(timezone.utc),
+            )
+            db.session.add(group_message)
+            db.session.flush()
+
+            attachment = GroupMessageAttachment(
+                group_message_id=group_message.id,
+                media_type=upload_token.media_type,
+                storage_path=upload_token.storage_path,
+                duration_seconds=upload_token.duration_seconds,
+                mime_type=upload_token.mime_type,
+            )
+            db.session.add(attachment)
+
+            if sender:
+                apply_progress(sender, 10)
+
+            upload_token.mark_consumed()
+            db.session.commit()
+
+            payload = {
+                "group_id": group_id,
+                "alias": membership.alias,
+                "message": caption,
+                "timestamp": group_message.timestamp.isoformat(),
+                "attachments": [
+                    {
+                        "media_type": media_payload["media_type"],
+                        "storage_path": media_payload["storage_path"],
+                        "duration_seconds": media_payload["duration_seconds"],
+                        "mime_type": media_payload["mime_type"],
+                    }
+                ],
+            }
+            emit("receive_group_message", payload, room=f"group_{group_id}")
+
+            if sender:
+                socketio.emit(
+                    "progress_update",
+                    {"xp": sender.xp, "level": sender.level, "badge": sender.badge},
+                    room=f"user_{sender.id}",
+                )
+            return
+
+        username = data.get("username")
+        recipient_username = data.get("recipient")
+        if not username or username != session.get("username"):
+            emit("error", {"error": "You are not authorized to send this media."})
+            return
+        if not recipient_username:
+            emit("error", {"error": "Recipient is required."})
+            return
+
+        recipient = User.query.filter_by(username=recipient_username).first()
+        if not recipient:
+            emit("error", {"error": "Recipient not found!"})
+            return
+
+        new_message = Message(
+            user_id=session["user_id"],
+            recipient_id=recipient.id,
+            text=caption,
+            timestamp=datetime.now(timezone.utc),
+        )
+        db.session.add(new_message)
+        db.session.flush()
+
+        attachment = MessageAttachment(
+            message_id=new_message.id,
+            media_type=upload_token.media_type,
+            storage_path=upload_token.storage_path,
+            duration_seconds=upload_token.duration_seconds,
+            mime_type=upload_token.mime_type,
+        )
+        db.session.add(attachment)
+
+        if sender:
+            apply_progress(sender, 8)
+
+        upload_token.mark_consumed()
+        db.session.commit()
+
+        payload = {
+            "username": username,
+            "recipient": recipient.username,
+            "message": caption,
+            "timestamp": new_message.timestamp.isoformat(),
+            "attachments": [
+                {
+                    "media_type": media_payload["media_type"],
+                    "storage_path": media_payload["storage_path"],
+                    "duration_seconds": media_payload["duration_seconds"],
+                    "mime_type": media_payload["mime_type"],
+                }
+            ],
+        }
+        recipient_room = f"user_{recipient.id}"
+        sender_room = f"user_{session['user_id']}"
+        emit("receive_message", payload, room=recipient_room)
+        emit("receive_message", payload, room=sender_room)
 
         if sender:
             socketio.emit(

--- a/static/styles.css
+++ b/static/styles.css
@@ -46,6 +46,89 @@ main {
     padding: 1rem;
 }
 
+.chat-message {
+    background: rgba(15, 23, 42, 0.55);
+    border-radius: 0.75rem;
+    padding: 0.75rem 1rem;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.chat-message-header {
+    font-size: 0.95rem;
+    font-weight: 600;
+}
+
+.chat-message-body {
+    margin-top: 0.4rem;
+    font-size: 0.95rem;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.chat-attachments {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 0.75rem;
+}
+
+.chat-media-card {
+    background: rgba(15, 23, 42, 0.7);
+    border-radius: 0.75rem;
+    padding: 0.75rem;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    max-width: 280px;
+    box-shadow: 0 0.5rem 1.25rem rgba(15, 23, 42, 0.35);
+}
+
+.chat-media {
+    display: block;
+    width: 100%;
+    border-radius: 0.5rem;
+}
+
+.chat-media-image {
+    object-fit: cover;
+    max-height: 220px;
+}
+
+.chat-media-meta {
+    margin-top: 0.5rem;
+}
+
+.chat-composer {
+    background: rgba(15, 23, 42, 0.5);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    border-radius: 0.75rem;
+    padding: 0.75rem 1rem;
+}
+
+.chat-composer .btn-group .btn {
+    min-width: 110px;
+}
+
+.chat-composer .btn-link {
+    text-decoration: none;
+}
+
+.attachment-preview {
+    border-radius: 0.5rem;
+    border: 1px dashed rgba(148, 163, 184, 0.4);
+    padding: 0.5rem;
+    margin-bottom: 0.75rem;
+    background: rgba(15, 23, 42, 0.35);
+}
+
+.attachment-preview video,
+.attachment-preview audio,
+.attachment-preview img {
+    max-height: 200px;
+}
+
+#message-form.is-uploading {
+    opacity: 0.8;
+}
+
 #user-list,
 #group-list {
     max-height: 40vh;

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -94,11 +94,41 @@
                 </div>
                 <div id="chat-box" class="chat-box flex-grow-1">
                     {% for message in messages %}
-                    <div class="mb-2" title="{{ message.timestamp.strftime('%d.%m.%Y, %H:%M:%S') }}">
-                        <strong class="{{ 'text-primary' if message.user_id == session['user_id'] else 'text-secondary' }}">
-                            {{ 'You' if message.user_id == session['user_id'] else message.sender.username }}:
-                        </strong>
-                        {{ message.text }}
+                    <div class="chat-message mb-3" title="{{ message.timestamp.strftime('%d.%m.%Y, %H:%M:%S') }}">
+                        <div class="chat-message-header">
+                            <strong class="{{ 'text-primary' if message.user_id == session['user_id'] else 'text-secondary' }}">
+                                {{ 'You' if message.user_id == session['user_id'] else message.sender.username }}:
+                            </strong>
+                        </div>
+                        {% if message.text %}
+                        <div class="chat-message-body">{{ message.text }}</div>
+                        {% endif %}
+                        {% if message.attachments %}
+                        <div class="chat-attachments">
+                            {% for attachment in message.attachments %}
+                            <div class="chat-media-card">
+                                {% if attachment.media_type == 'image' %}
+                                <img src="{{ url_for('serve_upload', filename=attachment.storage_path) }}" alt="Shared image" class="chat-media chat-media-image">
+                                {% elif attachment.media_type == 'audio' %}
+                                <audio controls class="chat-media" preload="none">
+                                    <source src="{{ url_for('serve_upload', filename=attachment.storage_path) }}" type="{{ attachment.mime_type or 'audio/mpeg' }}">
+                                    Your browser does not support the audio element.
+                                </audio>
+                                {% elif attachment.media_type == 'video' %}
+                                <video controls class="chat-media" preload="metadata">
+                                    <source src="{{ url_for('serve_upload', filename=attachment.storage_path) }}" type="{{ attachment.mime_type or 'video/mp4' }}">
+                                    Your browser does not support the video element.
+                                </video>
+                                {% else %}
+                                <a href="{{ url_for('serve_upload', filename=attachment.storage_path) }}" target="_blank" rel="noopener">Download attachment</a>
+                                {% endif %}
+                                {% if attachment.duration_seconds %}
+                                <div class="chat-media-meta small text-muted">{{ attachment.duration_seconds|round(1) }}s</div>
+                                {% endif %}
+                            </div>
+                            {% endfor %}
+                        </div>
+                        {% endif %}
                     </div>
                     {% endfor %}
                 </div>
@@ -109,8 +139,20 @@
                       data-chat-type="direct"
                       data-username="{{ session['username'] }}"
                       data-recipient="{{ recipient.username }}">
+                    <div class="chat-composer mb-2">
+                        <div id="attachment-preview" class="attachment-preview d-none"></div>
+                        <div class="d-flex flex-wrap align-items-center gap-2">
+                            <div class="btn-group" role="group" aria-label="Add media">
+                                <button type="button" class="btn btn-outline-secondary btn-sm" id="attachment-upload-btn">Upload</button>
+                                <button type="button" class="btn btn-outline-secondary btn-sm" id="voice-record-btn">Voice Clip</button>
+                                <button type="button" class="btn btn-outline-secondary btn-sm" id="video-record-btn">Video Clip</button>
+                            </div>
+                            <button type="button" class="btn btn-link text-danger btn-sm d-none" id="attachment-clear-btn">Clear</button>
+                        </div>
+                        <input type="file" id="attachment-file-input" accept="image/*,audio/*,video/*" class="d-none">
+                    </div>
                     <div class="input-group">
-                        <input id="message-input" type="text" name="message" class="form-control" placeholder="Type your message..." required>
+                        <input id="message-input" type="text" name="message" class="form-control" placeholder="Type your message...">
                         <button type="submit" class="btn btn-primary">Send</button>
                     </div>
                 </form>
@@ -134,11 +176,41 @@
                 {% endif %}
                 <div id="chat-box" class="chat-box flex-grow-1">
                     {% for message in group_messages %}
-                    <div class="mb-2" title="{{ message.timestamp.strftime('%d.%m.%Y, %H:%M:%S') }}">
-                        <strong class="{{ 'text-primary' if message.membership.user_id == session['user_id'] else 'text-secondary' }}">
-                            {{ 'You' if message.membership.user_id == session['user_id'] else message.alias }}:
-                        </strong>
-                        {{ message.text }}
+                    <div class="chat-message mb-3" title="{{ message.timestamp.strftime('%d.%m.%Y, %H:%M:%S') }}">
+                        <div class="chat-message-header">
+                            <strong class="{{ 'text-primary' if message.membership.user_id == session['user_id'] else 'text-secondary' }}">
+                                {{ 'You' if message.membership.user_id == session['user_id'] else message.alias }}:
+                            </strong>
+                        </div>
+                        {% if message.text %}
+                        <div class="chat-message-body">{{ message.text }}</div>
+                        {% endif %}
+                        {% if message.attachments %}
+                        <div class="chat-attachments">
+                            {% for attachment in message.attachments %}
+                            <div class="chat-media-card">
+                                {% if attachment.media_type == 'image' %}
+                                <img src="{{ url_for('serve_upload', filename=attachment.storage_path) }}" alt="Shared image" class="chat-media chat-media-image">
+                                {% elif attachment.media_type == 'audio' %}
+                                <audio controls class="chat-media" preload="none">
+                                    <source src="{{ url_for('serve_upload', filename=attachment.storage_path) }}" type="{{ attachment.mime_type or 'audio/mpeg' }}">
+                                    Your browser does not support the audio element.
+                                </audio>
+                                {% elif attachment.media_type == 'video' %}
+                                <video controls class="chat-media" preload="metadata">
+                                    <source src="{{ url_for('serve_upload', filename=attachment.storage_path) }}" type="{{ attachment.mime_type or 'video/mp4' }}">
+                                    Your browser does not support the video element.
+                                </video>
+                                {% else %}
+                                <a href="{{ url_for('serve_upload', filename=attachment.storage_path) }}" target="_blank" rel="noopener">Download attachment</a>
+                                {% endif %}
+                                {% if attachment.duration_seconds %}
+                                <div class="chat-media-meta small text-muted">{{ attachment.duration_seconds|round(1) }}s</div>
+                                {% endif %}
+                            </div>
+                            {% endfor %}
+                        </div>
+                        {% endif %}
                     </div>
                     {% endfor %}
                 </div>
@@ -149,8 +221,20 @@
                       data-chat-type="group"
                       data-group-id="{{ group.id }}"
                       data-alias="{{ membership.alias }}">
+                    <div class="chat-composer mb-2">
+                        <div id="attachment-preview" class="attachment-preview d-none"></div>
+                        <div class="d-flex flex-wrap align-items-center gap-2">
+                            <div class="btn-group" role="group" aria-label="Add media">
+                                <button type="button" class="btn btn-outline-secondary btn-sm" id="attachment-upload-btn">Upload</button>
+                                <button type="button" class="btn btn-outline-secondary btn-sm" id="voice-record-btn">Voice Clip</button>
+                                <button type="button" class="btn btn-outline-secondary btn-sm" id="video-record-btn">Video Clip</button>
+                            </div>
+                            <button type="button" class="btn btn-link text-danger btn-sm d-none" id="attachment-clear-btn">Clear</button>
+                        </div>
+                        <input type="file" id="attachment-file-input" accept="image/*,audio/*,video/*" class="d-none">
+                    </div>
                     <div class="input-group">
-                        <input id="message-input" type="text" name="message" class="form-control" placeholder="Type your message..." required>
+                        <input id="message-input" type="text" name="message" class="form-control" placeholder="Type your message...">
                         <button type="submit" class="btn btn-primary">Send</button>
                     </div>
                 </form>


### PR DESCRIPTION
## Summary
- add database models and schema migrations for message attachments and pending media uploads
- expose upload API endpoints with validation and create Socket.IO handlers for media messages
- update chat UI scripts and styles to handle media capture, uploads, and inline playback

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68f14a99727c832b97ee3a1e69018f0f