### PR TITLE
Add WebRTC call management and admin oversight

### DIFF
--- a/call_sessions.py
+++ b/call_sessions.py
@@ -1,0 +1,143 @@
+"""Call session state management utilities."""
+
+from __future__ import annotations
+
+import secrets
+import string
+from datetime import datetime, timezone
+from typing import Dict, Optional, Tuple
+
+from flask import current_app
+
+from models import CallSession, User, db
+
+
+class CallSessionManager:
+    """Manage lifecycle of voice/video call sessions."""
+
+    def __init__(self) -> None:
+        self._active_by_room: Dict[str, int] = {}
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _generate_room_id(self) -> str:
+        alphabet = string.ascii_letters + string.digits
+        return "".join(secrets.choice(alphabet) for _ in range(24))
+
+    def _mark_active(self, session: CallSession) -> None:
+        self._active_by_room[session.room_id] = session.id
+
+    def _clear_active(self, session: CallSession) -> None:
+        self._active_by_room.pop(session.room_id, None)
+
+    # ------------------------------------------------------------------
+    # lookups
+    # ------------------------------------------------------------------
+    def get_session(self, session_id: int) -> Optional[CallSession]:
+        return CallSession.query.get(session_id)
+
+    def get_session_by_room(self, room_id: str) -> Optional[CallSession]:
+        session_id = self._active_by_room.get(room_id)
+        if session_id:
+            return CallSession.query.get(session_id)
+        return CallSession.query.filter_by(room_id=room_id).first()
+
+    def get_active_sessions(self):
+        return CallSession.query.filter(CallSession.status.in_(["ringing", "active"]))
+
+    # ------------------------------------------------------------------
+    # permissions
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _can_call(user: User) -> bool:
+        return not user.is_blocked
+
+    def _is_user_busy(self, user_id: int) -> bool:
+        return (
+            CallSession.query.filter(
+                CallSession.status.in_(["ringing", "active"]),
+                (CallSession.caller_id == user_id) | (CallSession.callee_id == user_id),
+            ).first()
+            is not None
+        )
+
+    # ------------------------------------------------------------------
+    # lifecycle actions
+    # ------------------------------------------------------------------
+    def start_call(self, caller: User, callee: User) -> Tuple[Optional[CallSession], Optional[str]]:
+        """Attempt to start a call. Returns the session and an error message."""
+
+        if not self._can_call(caller):
+            return None, "You are blocked from placing calls."
+        if not self._can_call(callee):
+            return None, "The selected user cannot receive calls."
+        if caller.id == callee.id:
+            return None, "You cannot call yourself."
+        if self._is_user_busy(caller.id):
+            return None, "You already have an active call."
+        if self._is_user_busy(callee.id):
+            return None, "That user is busy in another call."
+
+        room_id = self._generate_room_id()
+        session = CallSession(
+            room_id=room_id,
+            caller_id=caller.id,
+            callee_id=callee.id,
+            status="ringing",
+            started_at=datetime.now(timezone.utc),
+        )
+        db.session.add(session)
+        db.session.commit()
+        self._mark_active(session)
+        current_app.logger.debug("Created call session %s", session.id)
+        return session, None
+
+    def accept_call(self, session: CallSession, callee: User) -> Optional[str]:
+        if session.callee_id != callee.id:
+            return "You are not allowed to answer this call."
+        if session.status not in {"ringing", "active"}:
+            return "Call is no longer available."
+
+        session.status = "active"
+        session.accepted_at = datetime.now(timezone.utc)
+        db.session.commit()
+        self._mark_active(session)
+        return None
+
+    def decline_call(self, session: CallSession, callee: User) -> Optional[str]:
+        if session.callee_id != callee.id:
+            return "You are not allowed to decline this call."
+        if session.status != "ringing":
+            return "Call is no longer available."
+
+        session.status = "declined"
+        session.ended_at = datetime.now(timezone.utc)
+        session.ended_by_id = callee.id
+        db.session.commit()
+        self._clear_active(session)
+        return None
+
+    def end_call(self, session: CallSession, user: Optional[User], *, moderator: bool = False) -> None:
+        if session.status not in {"ringing", "active"}:
+            return
+
+        session.status = "ended"
+        session.ended_at = datetime.now(timezone.utc)
+        if user:
+            session.ended_by_id = user.id
+        session.terminated_by_moderator = moderator
+        db.session.commit()
+        self._clear_active(session)
+
+    def mark_notes(self, session: CallSession, notes: Optional[str]) -> None:
+        session.notes = notes
+        db.session.commit()
+
+    def set_user_blocked(self, user: User, blocked: bool) -> None:
+        user.is_blocked = blocked
+        db.session.commit()
+
+    def is_user_blocked(self, user_id: int) -> bool:
+        user = User.query.get(user_id)
+        return bool(user and user.is_blocked)

--- a/event_handlers.py
+++ b/event_handlers.py
@@ -8,10 +8,18 @@ from flask import session
 from flask_socketio import emit, join_room, leave_room
 
 from achievements import apply_progress
-from models import BlockedWord, GroupMembership, GroupMessage, Message, User, db
+from models import (
+    BlockedWord,
+    CallSession,
+    GroupMembership,
+    GroupMessage,
+    Message,
+    User,
+    db,
+)
 
 
-def register_event_handlers(socketio, app):
+def register_event_handlers(socketio, app, call_manager):
     """Register SocketIO event handlers."""
 
     @socketio.on("send_message")
@@ -192,6 +200,162 @@ def register_event_handlers(socketio, app):
             for membership in GroupMembership.query.filter_by(user_id=user_id).all():
                 join_room(f"group_{membership.group_id}")
 
+    @socketio.on("call_request")
+    def handle_call_request(data):
+        """Initiate a WebRTC call."""
+
+        user_id = session.get("user_id")
+        if not user_id:
+            emit("call_error", {"error": "Login required."})
+            return
+
+        target_username = (data or {}).get("target")
+        offer = (data or {}).get("offer")
+        if not target_username:
+            emit("call_error", {"error": "Select someone to call."})
+            return
+        if not offer:
+            emit("call_error", {"error": "Missing WebRTC offer."})
+            return
+
+        caller = User.query.get(user_id)
+        callee = User.query.filter_by(username=target_username).first()
+        if not callee:
+            emit("call_error", {"error": "Recipient not found."})
+            return
+
+        session_obj, error = call_manager.start_call(caller, callee)
+        if error:
+            emit("call_error", {"error": error})
+            return
+
+        join_room(session_obj.room_id)
+        emit(
+            "call_outgoing",
+            {
+                "sessionId": session_obj.id,
+                "roomId": session_obj.room_id,
+                "recipient": callee.username,
+            },
+        )
+        socketio.emit(
+            "call_incoming",
+            {
+                "sessionId": session_obj.id,
+                "roomId": session_obj.room_id,
+                "caller": caller.username,
+                "offer": offer,
+            },
+            room=f"user_{callee.id}",
+        )
+
+    @socketio.on("call_answer")
+    def handle_call_answer(data):
+        """Handle callee response to a call."""
+
+        user_id = session.get("user_id")
+        if not user_id:
+            emit("call_error", {"error": "Login required."})
+            return
+
+        session_id = (data or {}).get("sessionId")
+        accepted = bool((data or {}).get("accepted"))
+        answer = (data or {}).get("answer")
+        session_obj = call_manager.get_session(session_id)
+        if not session_obj:
+            emit("call_error", {"error": "Call not found."})
+            return
+
+        callee = User.query.get(user_id)
+        if session_obj.callee_id != callee.id:
+            emit("call_error", {"error": "You are not part of this call."})
+            return
+
+        if not accepted:
+            error = call_manager.decline_call(session_obj, callee)
+            if error:
+                emit("call_error", {"error": error})
+            else:
+                socketio.emit(
+                    "call_declined",
+                    {"sessionId": session_obj.id, "roomId": session_obj.room_id},
+                    room=f"user_{session_obj.caller_id}",
+                )
+            return
+
+        if not answer:
+            emit("call_error", {"error": "Missing WebRTC answer."})
+            return
+
+        error = call_manager.accept_call(session_obj, callee)
+        if error:
+            emit("call_error", {"error": error})
+            return
+
+        join_room(session_obj.room_id)
+        socketio.emit(
+            "call_answered",
+            {
+                "sessionId": session_obj.id,
+                "roomId": session_obj.room_id,
+                "answer": answer,
+            },
+            room=session_obj.room_id,
+        )
+
+    @socketio.on("ice_candidate")
+    def handle_ice_candidate(data):
+        """Relay ICE candidates between peers."""
+
+        user_id = session.get("user_id")
+        if not user_id:
+            return
+
+        session_id = (data or {}).get("sessionId")
+        candidate = (data or {}).get("candidate")
+        session_obj = call_manager.get_session(session_id)
+        if not session_obj or not candidate:
+            return
+
+        if user_id not in {session_obj.caller_id, session_obj.callee_id}:
+            return
+
+        socketio.emit(
+            "ice_candidate",
+            {"sessionId": session_obj.id, "candidate": candidate},
+            room=session_obj.room_id,
+            include_self=False,
+        )
+
+    @socketio.on("call_hangup")
+    def handle_call_hangup(data):
+        """Terminate a call initiated by a participant."""
+
+        user_id = session.get("user_id")
+        if not user_id:
+            return
+
+        session_id = (data or {}).get("sessionId")
+        session_obj = call_manager.get_session(session_id)
+        if not session_obj:
+            return
+
+        if user_id not in {session_obj.caller_id, session_obj.callee_id}:
+            return
+
+        user = User.query.get(user_id)
+        call_manager.end_call(session_obj, user)
+        socketio.emit(
+            "call_ended",
+            {
+                "sessionId": session_obj.id,
+                "roomId": session_obj.room_id,
+                "endedBy": user.username if user else None,
+            },
+            room=session_obj.room_id,
+        )
+        leave_room(session_obj.room_id)
+
     @socketio.on("disconnect")
     def handle_disconnect():
         """Handle the "disconnect" event."""
@@ -201,3 +365,25 @@ def register_event_handlers(socketio, app):
             leave_room(f"user_{user_id}")
             for membership in GroupMembership.query.filter_by(user_id=user_id).all():
                 leave_room(f"group_{membership.group_id}")
+
+            active_sessions = (
+                call_manager.get_active_sessions()
+                .filter(
+                    (CallSession.caller_id == user_id)
+                    | (CallSession.callee_id == user_id)
+                )
+                .all()
+            )
+            user = User.query.get(user_id)
+            for session_obj in active_sessions:
+                call_manager.end_call(session_obj, user)
+                socketio.emit(
+                    "call_ended",
+                    {
+                        "sessionId": session_obj.id,
+                        "roomId": session_obj.room_id,
+                        "endedBy": user.username if user else None,
+                    },
+                    room=session_obj.room_id,
+                )
+                leave_room(session_obj.room_id)

--- a/models.py
+++ b/models.py
@@ -28,6 +28,7 @@ class User(db.Model):
     last_arrival_at = db.Column(db.DateTime, default=datetime.now(timezone.utc), nullable=False)
     pin_hash = db.Column(db.String(200), nullable=True)
     is_admin = db.Column(db.Boolean, nullable=False, default=False)
+    is_blocked = db.Column(db.Boolean, nullable=False, default=False)
 
     @property
     def has_pin(self) -> bool:
@@ -117,3 +118,21 @@ class ModeratorAssignment(db.Model):
     assigned_at = db.Column(db.DateTime, default=datetime.now(timezone.utc), nullable=False)
 
     user = db.relationship('User', backref=db.backref('moderator_assignment', uselist=False))
+
+
+class CallSession(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    room_id = db.Column(db.String(64), unique=True, nullable=False)
+    caller_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    callee_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    status = db.Column(db.String(20), nullable=False, default="ringing")
+    started_at = db.Column(db.DateTime, default=datetime.now(timezone.utc), nullable=False)
+    accepted_at = db.Column(db.DateTime, nullable=True)
+    ended_at = db.Column(db.DateTime, nullable=True)
+    ended_by_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
+    terminated_by_moderator = db.Column(db.Boolean, nullable=False, default=False)
+    notes = db.Column(db.String(255), nullable=True)
+
+    caller = db.relationship('User', foreign_keys=[caller_id], backref='outgoing_calls')
+    callee = db.relationship('User', foreign_keys=[callee_id], backref='incoming_calls')
+    ended_by = db.relationship('User', foreign_keys=[ended_by_id])

--- a/static/styles.css
+++ b/static/styles.css
@@ -168,3 +168,56 @@ body.locked {
     max-height: 320px;
     overflow-y: auto;
 }
+
+.call-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 1rem;
+}
+
+.call-toolbar .btn-group {
+    flex-wrap: wrap;
+}
+
+.call-toolbar .btn {
+    min-width: 120px;
+}
+
+.call-status-banner {
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    background: rgba(59, 130, 246, 0.15);
+    color: #dbeafe;
+}
+
+.call-video-wrapper {
+    background: rgba(15, 23, 42, 0.5);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    border-radius: 0.75rem;
+    padding: 1rem;
+}
+
+.call-video-grid {
+    display: grid;
+    gap: 1rem;
+}
+
+@media (min-width: 768px) {
+    .call-video-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+.call-video {
+    width: 100%;
+    background: rgba(30, 41, 59, 0.8);
+    border-radius: 0.75rem;
+    min-height: 180px;
+    object-fit: cover;
+}
+
+.modal .modal-body p {
+    font-size: 0.95rem;
+}

--- a/static/websocket.js
+++ b/static/websocket.js
@@ -1,16 +1,19 @@
 // This script handles the WebSocket communication between the client and the server
 
-document.addEventListener("DOMContentLoaded", function() {
+document.addEventListener("DOMContentLoaded", () => {
     const socket = io();
     const messageForm = document.getElementById("message-form");
     const messageInput = document.getElementById("message-input");
 
+    // ---------------------------------------------------------------------
+    // chat messaging
+    // ---------------------------------------------------------------------
     if (messageForm && messageForm.dataset.chatType === "group") {
         socket.emit("join_group_room", { group_id: messageForm.dataset.groupId });
     }
 
     if (messageForm) {
-        messageForm.addEventListener("submit", function(event) {
+        messageForm.addEventListener("submit", (event) => {
             event.preventDefault();
 
             if (!messageInput) {
@@ -27,13 +30,13 @@ document.addEventListener("DOMContentLoaded", function() {
                 socket.emit("send_group_message", {
                     group_id: messageForm.dataset.groupId,
                     alias: messageForm.dataset.alias,
-                    message: message
+                    message: message,
                 });
             } else {
                 socket.emit("send_message", {
                     username: messageForm.dataset.username,
                     recipient: messageForm.dataset.recipient,
-                    message: message
+                    message: message,
                 });
             }
 
@@ -41,7 +44,7 @@ document.addEventListener("DOMContentLoaded", function() {
         });
     }
 
-    socket.on("receive_message", function(data) {
+    socket.on("receive_message", (data) => {
         if (!messageForm || messageForm.dataset.chatType !== "direct") {
             return;
         }
@@ -55,7 +58,7 @@ document.addEventListener("DOMContentLoaded", function() {
         }
     });
 
-    socket.on("receive_group_message", function(data) {
+    socket.on("receive_group_message", (data) => {
         if (!messageForm || messageForm.dataset.chatType !== "group") {
             return;
         }
@@ -65,14 +68,400 @@ document.addEventListener("DOMContentLoaded", function() {
         appendMessage(data.alias, messageForm.dataset.alias, data.message, data.timestamp);
     });
 
-    socket.on("progress_update", function(data) {
+    socket.on("progress_update", (data) => {
         updateProgressDisplay(data);
     });
 
-    socket.on("error", function(data) {
+    socket.on("error", (data) => {
         if (data && data.error) {
-            console.warn('Chat error:', data.error);
+            console.warn("Chat error:", data.error);
             alert(data.error);
         }
+    });
+
+    // ---------------------------------------------------------------------
+    // WebRTC call handling
+    // ---------------------------------------------------------------------
+    const callStartButton = document.getElementById("call-start-btn");
+    const callAcceptButton = document.getElementById("call-accept-btn");
+    const callHangupButton = document.getElementById("call-hangup-btn");
+    const callStatusBanner = document.getElementById("call-status-banner");
+    const callVideoContainer = document.getElementById("call-video-container");
+    const localVideo = document.getElementById("local-video");
+    const remoteVideo = document.getElementById("remote-video");
+    const incomingModalElement = document.getElementById("incomingCallModal");
+    const incomingModal = incomingModalElement ? new bootstrap.Modal(incomingModalElement) : null;
+    const incomingCallFrom = document.getElementById("incoming-call-from");
+    const incomingAcceptButton = document.getElementById("incoming-call-accept");
+    const incomingDeclineButton = document.getElementById("incoming-call-decline");
+    const callStatusModalElement = document.getElementById("callStatusModal");
+    const callStatusModal = callStatusModalElement ? new bootstrap.Modal(callStatusModalElement) : null;
+    const callStatusMessage = document.getElementById("call-status-message");
+
+    const rtcConfig = {
+        iceServers: [{ urls: "stun:stun.l.google.com:19302" }],
+    };
+
+    let peerConnection = null;
+    let localStream = null;
+    let remoteStream = null;
+    let callState = "idle";
+    let currentCall = null;
+
+    function isDirectChat() {
+        return messageForm && messageForm.dataset.chatType === "direct";
+    }
+
+    function setBanner(message) {
+        if (!callStatusBanner) {
+            return;
+        }
+        if (!message) {
+            callStatusBanner.hidden = true;
+            callStatusBanner.textContent = "";
+            return;
+        }
+        callStatusBanner.hidden = false;
+        callStatusBanner.textContent = message;
+    }
+
+    function showStatus(message) {
+        if (callStatusModal && callStatusMessage) {
+            callStatusMessage.textContent = message;
+            callStatusModal.show();
+        } else {
+            setBanner(message);
+        }
+    }
+
+    function hideStatus() {
+        if (callStatusModal) {
+            callStatusModal.hide();
+        }
+        setBanner("");
+    }
+
+    function updateControls() {
+        if (!callStartButton || !callHangupButton || !callAcceptButton) {
+            return;
+        }
+
+        const acceptVisible = callState === "ringing";
+        const hangupVisible = ["calling", "active", "ringing"].includes(callState);
+        const startVisible = callState === "idle";
+
+        callStartButton.classList.toggle("d-none", !startVisible);
+        callHangupButton.classList.toggle("d-none", !hangupVisible);
+        callAcceptButton.classList.toggle("d-none", !acceptVisible);
+    }
+
+    function resetVideo() {
+        if (callVideoContainer) {
+            callVideoContainer.classList.add("d-none");
+        }
+        if (localVideo) {
+            localVideo.srcObject = null;
+        }
+        if (remoteVideo) {
+            remoteVideo.srcObject = null;
+        }
+        remoteStream = null;
+    }
+
+    function showVideo() {
+        if (callVideoContainer) {
+            callVideoContainer.classList.remove("d-none");
+        }
+    }
+
+    async function ensureLocalStream() {
+        if (localStream) {
+            return localStream;
+        }
+        try {
+            localStream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+            if (localVideo) {
+                localVideo.srcObject = localStream;
+            }
+            showVideo();
+            return localStream;
+        } catch (error) {
+            console.error("Media capture failed", error);
+            showStatus("Microphone or camera access was denied.");
+            throw error;
+        }
+    }
+
+    function createPeerConnection() {
+        if (peerConnection) {
+            peerConnection.close();
+        }
+        peerConnection = new RTCPeerConnection(rtcConfig);
+        peerConnection.onicecandidate = (event) => {
+            if (event.candidate && currentCall) {
+                socket.emit("ice_candidate", {
+                    sessionId: currentCall.id,
+                    candidate: event.candidate,
+                });
+            }
+        };
+        peerConnection.ontrack = (event) => {
+            if (!remoteStream) {
+                remoteStream = new MediaStream();
+                if (remoteVideo) {
+                    remoteVideo.srcObject = remoteStream;
+                }
+            }
+            event.streams[0].getTracks().forEach((track) => {
+                remoteStream.addTrack(track);
+            });
+            showVideo();
+        };
+
+        if (localStream) {
+            localStream.getTracks().forEach((track) => {
+                peerConnection.addTrack(track, localStream);
+            });
+        }
+
+        return peerConnection;
+    }
+
+    function cleanupCall(message) {
+        if (peerConnection) {
+            peerConnection.ontrack = null;
+            peerConnection.onicecandidate = null;
+            peerConnection.close();
+            peerConnection = null;
+        }
+        if (localStream) {
+            localStream.getTracks().forEach((track) => track.stop());
+            localStream = null;
+        }
+        resetVideo();
+        callState = "idle";
+        currentCall = null;
+        updateControls();
+        hideStatus();
+        if (incomingModal) {
+            incomingModal.hide();
+        }
+        if (message) {
+            setBanner(message);
+        }
+    }
+
+    async function startOutgoingCall() {
+        if (!isDirectChat() || callState !== "idle" || !callStartButton) {
+            return;
+        }
+        const recipient = callStartButton.dataset.recipient;
+        if (!recipient) {
+            return;
+        }
+
+        try {
+            await ensureLocalStream();
+        } catch (error) {
+            return;
+        }
+
+        createPeerConnection();
+        callState = "calling";
+        currentCall = {
+            id: null,
+            roomId: null,
+            partner: recipient,
+            role: "caller",
+        };
+        updateControls();
+        showStatus(`Calling ${recipient}…`);
+
+        try {
+            const offer = await peerConnection.createOffer();
+            await peerConnection.setLocalDescription(offer);
+            socket.emit("call_request", {
+                target: recipient,
+                offer: offer,
+            });
+        } catch (error) {
+            console.error("Failed to start call", error);
+            cleanupCall("Could not start the call.");
+        }
+    }
+
+    async function acceptIncomingCall() {
+        if (!currentCall || currentCall.role !== "callee") {
+            return;
+        }
+        try {
+            await ensureLocalStream();
+        } catch (error) {
+            declineIncomingCall();
+            return;
+        }
+
+        createPeerConnection();
+        updateControls();
+
+        try {
+            await peerConnection.setRemoteDescription(new RTCSessionDescription(currentCall.offer));
+            const answer = await peerConnection.createAnswer();
+            await peerConnection.setLocalDescription(answer);
+            callState = "active";
+            showStatus("Call connected.");
+            socket.emit("call_answer", {
+                sessionId: currentCall.id,
+                accepted: true,
+                answer: answer,
+            });
+        } catch (error) {
+            console.error("Failed to accept call", error);
+            cleanupCall("Call could not be connected.");
+            socket.emit("call_answer", {
+                sessionId: currentCall.id,
+                accepted: false,
+            });
+        }
+    }
+
+    function declineIncomingCall() {
+        if (!currentCall) {
+            return;
+        }
+        socket.emit("call_answer", {
+            sessionId: currentCall.id,
+            accepted: false,
+        });
+        cleanupCall("Call declined.");
+    }
+
+    function hangupCall() {
+        if (!currentCall) {
+            cleanupCall();
+            return;
+        }
+        socket.emit("call_hangup", { sessionId: currentCall.id });
+        cleanupCall("Call ended.");
+    }
+
+    if (callStartButton) {
+        callStartButton.addEventListener("click", startOutgoingCall);
+    }
+    if (callAcceptButton) {
+        callAcceptButton.addEventListener("click", acceptIncomingCall);
+    }
+    if (callHangupButton) {
+        callHangupButton.addEventListener("click", hangupCall);
+    }
+    if (incomingAcceptButton) {
+        incomingAcceptButton.addEventListener("click", () => {
+            if (incomingModal) {
+                incomingModal.hide();
+            }
+            acceptIncomingCall();
+        });
+    }
+    if (incomingDeclineButton) {
+        incomingDeclineButton.addEventListener("click", () => {
+            declineIncomingCall();
+        });
+    }
+
+    function handleIncomingCall(data) {
+        if (callState !== "idle") {
+            socket.emit("call_answer", { sessionId: data.sessionId, accepted: false });
+            return;
+        }
+        if (!isDirectChat()) {
+            showStatus(`Incoming call from ${data.caller}. Open their chat to answer.`);
+            return;
+        }
+        if (messageForm.dataset.recipient !== data.caller) {
+            showStatus(`Incoming call from ${data.caller}. Switch chats to respond.`);
+            return;
+        }
+
+        currentCall = {
+            id: data.sessionId,
+            roomId: data.roomId,
+            partner: data.caller,
+            offer: data.offer,
+            role: "callee",
+        };
+        callState = "ringing";
+        updateControls();
+        setBanner(`Incoming call from ${data.caller}`);
+        if (incomingCallFrom) {
+            incomingCallFrom.textContent = data.caller;
+        }
+        if (incomingModal) {
+            incomingModal.show();
+        }
+    }
+
+    socket.on("call_outgoing", (data) => {
+        if (!currentCall || currentCall.role !== "caller") {
+            return;
+        }
+        currentCall.id = data.sessionId;
+        currentCall.roomId = data.roomId;
+        callState = "calling";
+        updateControls();
+        setBanner(`Calling ${currentCall.partner}…`);
+    });
+
+    socket.on("call_incoming", (data) => {
+        handleIncomingCall(data);
+    });
+
+    socket.on("call_answered", async (data) => {
+        if (!currentCall || data.sessionId !== currentCall.id) {
+            return;
+        }
+        if (currentCall.role === "caller" && peerConnection) {
+            try {
+                await peerConnection.setRemoteDescription(new RTCSessionDescription(data.answer));
+                callState = "active";
+                setBanner("Call connected.");
+                showVideo();
+            } catch (error) {
+                console.error("Failed to process answer", error);
+                cleanupCall("Call failed to connect.");
+            }
+        }
+    });
+
+    socket.on("call_declined", (data) => {
+        if (!currentCall || data.sessionId !== currentCall.id) {
+            return;
+        }
+        cleanupCall("Call was declined.");
+    });
+
+    socket.on("call_ended", (data) => {
+        if (!currentCall || data.sessionId !== currentCall.id) {
+            cleanupCall("Call ended.");
+            return;
+        }
+        const endedBy = data.endedBy ? ` by ${data.endedBy}` : "";
+        cleanupCall(`Call ended${endedBy}.`);
+    });
+
+    socket.on("ice_candidate", async (data) => {
+        if (!currentCall || data.sessionId !== currentCall.id || !peerConnection) {
+            return;
+        }
+        try {
+            await peerConnection.addIceCandidate(new RTCIceCandidate(data.candidate));
+        } catch (error) {
+            console.error("Error adding ICE candidate", error);
+        }
+    });
+
+    socket.on("call_error", (data) => {
+        const message = data && data.error ? data.error : "Call error";
+        console.warn("Call error:", message);
+        cleanupCall(message);
     });
 });

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -42,6 +42,134 @@
             </div>
         </div>
 
+        <div class="col-12">
+            <div class="card admin-panel border-0">
+                <div class="card-body">
+                    <h4 class="mb-3">Call Oversight</h4>
+                    <form method="post" class="row g-2 align-items-end mb-4">
+                        <input type="hidden" name="action" value="toggle_call_block">
+                        <div class="col-md-6">
+                            <label class="form-label" for="call-access-user">Toggle call access</label>
+                            <select id="call-access-user" name="target-user-id" class="form-select" required>
+                                <option value="" selected disabled>Choose user…</option>
+                                {% for user in users %}
+                                    <option value="{{ user.id }}">{{ user.username }}{% if user.is_blocked %} (Blocked){% endif %}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label">Current status</label>
+                            <div class="form-control-plaintext fw-semibold">Updates after submission</div>
+                        </div>
+                        <div class="col-md-3 d-grid">
+                            <button class="btn btn-outline-light" type="submit">Toggle Call Access</button>
+                        </div>
+                    </form>
+
+                    <div class="row g-4">
+                        <div class="col-12 col-lg-6">
+                            <h5 class="mb-3">Live Sessions</h5>
+                            <div class="admin-table-wrapper">
+                                <table class="table table-sm table-dark align-middle mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th scope="col">Caller</th>
+                                            <th scope="col">Callee</th>
+                                            <th scope="col">Started</th>
+                                            <th scope="col">Status</th>
+                                            <th scope="col" class="text-end">Actions</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {% for call in live_calls %}
+                                        <tr>
+                                            <td>{{ call.caller.username if call.caller else '—' }}</td>
+                                            <td>{{ call.callee.username if call.callee else '—' }}</td>
+                                            <td>{{ call.started_at.astimezone().strftime('%Y-%m-%d %H:%M') }}</td>
+                                            <td>
+                                                {% if call.status == 'active' %}
+                                                    <span class="badge text-bg-success">Active</span>
+                                                {% elif call.status == 'ringing' %}
+                                                    <span class="badge text-bg-warning text-dark">Ringing</span>
+                                                {% else %}
+                                                    <span class="badge text-bg-secondary">{{ call.status }}</span>
+                                                {% endif %}
+                                            </td>
+                                            <td class="text-end">
+                                                <form method="post" class="d-inline">
+                                                    <input type="hidden" name="action" value="terminate_call">
+                                                    <input type="hidden" name="session-id" value="{{ call.id }}">
+                                                    <button class="btn btn-sm btn-outline-danger" type="submit">Terminate</button>
+                                                </form>
+                                            </td>
+                                        </tr>
+                                        {% else %}
+                                        <tr>
+                                            <td colspan="5" class="text-center text-muted">No live calls currently.</td>
+                                        </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                        <div class="col-12 col-lg-6">
+                            <h5 class="mb-3">Recent Call History</h5>
+                            <div class="admin-table-wrapper">
+                                <table class="table table-sm table-dark align-middle mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th scope="col">Caller</th>
+                                            <th scope="col">Callee</th>
+                                            <th scope="col">Ended</th>
+                                            <th scope="col">Status</th>
+                                            <th scope="col">Moderator</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {% for call in call_history %}
+                                        <tr>
+                                            <td>{{ call.caller.username if call.caller else '—' }}</td>
+                                            <td>{{ call.callee.username if call.callee else '—' }}</td>
+                                            <td>
+                                                {% if call.ended_at %}
+                                                    {{ call.ended_at.astimezone().strftime('%Y-%m-%d %H:%M') }}
+                                                {% else %}
+                                                    —
+                                                {% endif %}
+                                            </td>
+                                            <td>
+                                                {% if call.status == 'ended' %}
+                                                    <span class="badge text-bg-secondary">Ended</span>
+                                                {% elif call.status == 'declined' %}
+                                                    <span class="badge text-bg-warning text-dark">Declined</span>
+                                                {% else %}
+                                                    <span class="badge text-bg-info">{{ call.status|capitalize }}</span>
+                                                {% endif %}
+                                            </td>
+                                            <td>
+                                                {% if call.terminated_by_moderator %}
+                                                    <span class="badge text-bg-danger">Moderator</span>
+                                                {% elif call.ended_by %}
+                                                    {{ call.ended_by.username }}
+                                                {% else %}
+                                                    —
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                        {% else %}
+                                        <tr>
+                                            <td colspan="5" class="text-center text-muted">No calls recorded yet.</td>
+                                        </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <div class="col-12 col-xl-6">
             <div class="card admin-panel border-0 h-100">
                 <div class="card-body">

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -92,6 +92,33 @@
                         <span class="badge text-bg-warning text-dark" id="progress-badge">{{ current_user_profile.badge if current_user_profile else 'Newcomer' }}</span>
                     </div>
                 </div>
+                <div class="call-toolbar mb-3">
+                    <div class="btn-group" role="group" aria-label="Call controls">
+                        <button type="button"
+                                class="btn btn-outline-success call-action"
+                                id="call-start-btn"
+                                data-recipient="{{ recipient.username }}">
+                            Call
+                        </button>
+                        <button type="button"
+                                class="btn btn-outline-primary call-action d-none"
+                                id="call-accept-btn">
+                            Accept
+                        </button>
+                        <button type="button"
+                                class="btn btn-outline-danger call-action d-none"
+                                id="call-hangup-btn">
+                            Hang Up
+                        </button>
+                    </div>
+                    <div class="call-status-banner" id="call-status-banner" hidden></div>
+                </div>
+                <div class="call-video-wrapper d-none" id="call-video-container">
+                    <div class="call-video-grid">
+                        <video id="local-video" autoplay muted playsinline class="call-video"></video>
+                        <video id="remote-video" autoplay playsinline class="call-video"></video>
+                    </div>
+                </div>
                 <div id="chat-box" class="chat-box flex-grow-1">
                     {% for message in messages %}
                     <div class="mb-2" title="{{ message.timestamp.strftime('%d.%m.%Y, %H:%M:%S') }}">
@@ -165,6 +192,38 @@
                 <p class="lead">Select a direct message or hidden group to begin chatting.</p>
             </div>
             {% endif %}
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="incomingCallModal" tabindex="-1" aria-labelledby="incomingCallLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="incomingCallLabel">Incoming Call</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p class="mb-0">You have an incoming call from <strong id="incoming-call-from"></strong>.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary" id="incoming-call-decline" data-bs-dismiss="modal">Decline</button>
+                <button type="button" class="btn btn-primary" id="incoming-call-accept">Accept</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="callStatusModal" tabindex="-1" aria-labelledby="callStatusLabel" aria-hidden="true">
+    <div class="modal-dialog modal-sm modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="callStatusLabel">Call status</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p class="mb-0" id="call-status-message">Connecting…</p>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- add call controls and in-call modals to the chat interface with supporting styles
- implement WebRTC call setup in the client, new Socket.IO events, and a server call session manager
- expose REST APIs and admin dashboard controls for monitoring, blocking, and terminating live calls

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68f1516ede80832b8240e73df2889aa9