### PR TITLE
Add theming system and responsive layout improvements

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1,65 +1,171 @@
-html, body {
+:root {
+    color-scheme: light;
+    --body-bg: #f8fafc;
+    --body-text: #0f172a;
+    --text-muted: #475569;
+    --text-inverse: #f8fafc;
+    --surface: rgba(255, 255, 255, 0.85);
+    --surface-strong: rgba(248, 250, 252, 0.95);
+    --surface-muted: rgba(226, 232, 240, 0.7);
+    --surface-card: rgba(255, 255, 255, 0.65);
+    --border-subtle: rgba(148, 163, 184, 0.35);
+    --border-strong: rgba(100, 116, 139, 0.45);
+    --accent: #2563eb;
+    --accent-soft: rgba(37, 99, 235, 0.15);
+    --accent-strong: rgba(37, 99, 235, 0.25);
+    --shadow-soft: 0 1rem 2.5rem rgba(15, 23, 42, 0.12);
+    --shadow-strong: 0 1.5rem 4rem rgba(15, 23, 42, 0.18);
+}
+
+[data-theme="dark"] {
+    color-scheme: dark;
+    --body-bg: #0f172a;
+    --body-text: #e2e8f0;
+    --text-muted: #94a3b8;
+    --text-inverse: #0f172a;
+    --surface: rgba(15, 23, 42, 0.65);
+    --surface-strong: rgba(15, 23, 42, 0.9);
+    --surface-muted: rgba(30, 41, 59, 0.75);
+    --surface-card: rgba(15, 23, 42, 0.75);
+    --border-subtle: rgba(148, 163, 184, 0.2);
+    --border-strong: rgba(148, 163, 184, 0.35);
+    --accent: #60a5fa;
+    --accent-soft: rgba(96, 165, 250, 0.22);
+    --accent-strong: rgba(96, 165, 250, 0.32);
+    --shadow-soft: 0 1rem 2.5rem rgba(8, 15, 35, 0.55);
+    --shadow-strong: 0 1.5rem 4rem rgba(8, 15, 35, 0.75);
+}
+
+html,
+body {
     height: 100%;
+}
+
+body {
+    min-height: 100%;
     display: flex;
     flex-direction: column;
+    background: var(--body-bg);
+    color: var(--body-text);
+    transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+header,
+footer {
+    background: var(--surface);
+    transition: background-color 0.3s ease, border-color 0.3s ease;
+}
+
+footer {
+    border-top: 1px solid var(--border-subtle);
 }
 
 main {
     flex: 1;
 }
 
+.navbar {
+    backdrop-filter: blur(12px);
+    background-color: transparent !important;
+    transition: background-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.navbar .navbar-brand,
+.navbar .nav-link {
+    font-weight: 500;
+}
+
+.navbar .nav-link.active,
+.navbar .nav-link:hover,
+.navbar .nav-link:focus {
+    color: var(--accent) !important;
+}
+
+.theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 44px;
+    min-height: 38px;
+    padding: 0.35rem 0.75rem;
+    color: var(--body-text);
+    border-color: var(--border-strong);
+    background-color: transparent;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+    color: var(--accent);
+    background-color: var(--accent-soft);
+    border-color: var(--accent);
+}
+
+.theme-toggle .theme-icon {
+    display: none;
+    font-size: 1.15rem;
+    line-height: 1;
+}
+
+[data-theme="light"] .theme-toggle .theme-icon-light,
+[data-theme="dark"] .theme-toggle .theme-icon-dark {
+    display: inline-flex;
+}
+
 .access-form {
-    max-width: 400px;
+    max-width: 420px;
 }
 
 .active {
-    color: white;
-    font-weight: bold;
+    color: var(--accent) !important;
+    font-weight: 600;
 }
-
-/*
-.message-text {
-    word-wrap: break-word;
-    overflow-wrap: break-word;
-}
-*/
 
 .no-underline {
+    color: inherit;
     text-decoration: none;
+    transition: color 0.2s ease, text-decoration 0.2s ease;
 }
 
-/*
-.username {
-    font-weight: bold;
-    white-space: nowrap;
+.no-underline:hover {
+    text-decoration: underline;
 }
-*/
 
 #chat-box {
     height: 58vh;
     overflow-y: auto;
     word-wrap: break-word;
     text-align: left;
-    background-color: rgba(255, 255, 255, 0.02);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 0.5rem;
-    padding: 1rem;
+    background-color: var(--surface);
+    border: 1px solid var(--border-subtle);
+    border-radius: 0.75rem;
+    padding: 1.25rem;
+    box-shadow: var(--shadow-soft);
+    transition: background-color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
 }
 
 .chat-message {
-    background: rgba(15, 23, 42, 0.55);
-    border-radius: 0.75rem;
-    padding: 0.75rem 1rem;
-    border: 1px solid rgba(148, 163, 184, 0.18);
+    background: var(--surface-strong);
+    border-radius: 0.9rem;
+    padding: 0.9rem 1.1rem;
+    border: 1px solid var(--border-strong);
+    box-shadow: var(--shadow-soft);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.3s ease;
+}
+
+.chat-message:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-strong);
 }
 
 .chat-message-header {
     font-size: 0.95rem;
     font-weight: 600;
+    color: var(--text-muted);
 }
 
 .chat-message-body {
-    margin-top: 0.4rem;
+    margin-top: 0.5rem;
     font-size: 0.95rem;
     white-space: pre-wrap;
     word-break: break-word;
@@ -69,22 +175,28 @@ main {
     display: flex;
     flex-wrap: wrap;
     gap: 0.75rem;
-    margin-top: 0.75rem;
+    margin-top: 0.85rem;
 }
 
 .chat-media-card {
-    background: rgba(15, 23, 42, 0.7);
-    border-radius: 0.75rem;
-    padding: 0.75rem;
-    border: 1px solid rgba(148, 163, 184, 0.2);
+    background: var(--surface-card);
+    border-radius: 0.85rem;
+    padding: 0.85rem;
+    border: 1px solid var(--border-subtle);
     max-width: 280px;
-    box-shadow: 0 0.5rem 1.25rem rgba(15, 23, 42, 0.35);
+    box-shadow: var(--shadow-soft);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chat-media-card:hover {
+    transform: translateY(-3px);
+    box-shadow: var(--shadow-strong);
 }
 
 .chat-media {
     display: block;
     width: 100%;
-    border-radius: 0.5rem;
+    border-radius: 0.6rem;
 }
 
 .chat-media-image {
@@ -94,13 +206,16 @@ main {
 
 .chat-media-meta {
     margin-top: 0.5rem;
+    color: var(--text-muted);
 }
 
 .chat-composer {
-    background: rgba(15, 23, 42, 0.5);
-    border: 1px solid rgba(148, 163, 184, 0.2);
-    border-radius: 0.75rem;
-    padding: 0.75rem 1rem;
+    background: var(--surface);
+    border: 1px solid var(--border-subtle);
+    border-radius: 0.9rem;
+    padding: 0.85rem 1.1rem;
+    box-shadow: var(--shadow-soft);
+    transition: background-color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
 }
 
 .chat-composer .btn-group .btn {
@@ -112,17 +227,19 @@ main {
 }
 
 .attachment-preview {
-    border-radius: 0.5rem;
-    border: 1px dashed rgba(148, 163, 184, 0.4);
-    padding: 0.5rem;
+    border-radius: 0.7rem;
+    border: 1px dashed var(--border-subtle);
+    padding: 0.6rem;
     margin-bottom: 0.75rem;
-    background: rgba(15, 23, 42, 0.35);
+    background: var(--surface-muted);
+    transition: background-color 0.3s ease, border-color 0.3s ease;
 }
 
 .attachment-preview video,
 .attachment-preview audio,
 .attachment-preview img {
     max-height: 200px;
+    border-radius: 0.6rem;
 }
 
 #message-form.is-uploading {
@@ -137,6 +254,7 @@ main {
 
 #group-list .list-group-item {
     background-color: transparent;
+    border-color: var(--border-subtle);
 }
 
 .progress-info .badge {
@@ -146,13 +264,17 @@ main {
 .security-lock-overlay {
     position: fixed;
     inset: 0;
-    background: rgba(0, 0, 0, 0.92);
+    background: rgba(15, 23, 42, 0.85);
     display: none;
     align-items: center;
     justify-content: center;
     z-index: 2000;
     padding: 2rem;
     transition: opacity 0.3s ease;
+}
+
+[data-theme="light"] .security-lock-overlay {
+    background: rgba(15, 23, 42, 0.65);
 }
 
 .security-lock-overlay.active {
@@ -162,11 +284,12 @@ main {
 .security-lock-panel {
     max-width: 420px;
     width: 100%;
-    background: rgba(17, 24, 39, 0.95);
+    background: var(--surface-strong);
     border-radius: 1rem;
     padding: 2.5rem 2rem;
-    box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.35);
-    border: 1px solid rgba(59, 130, 246, 0.35);
+    box-shadow: var(--shadow-strong);
+    border: 1px solid var(--accent-strong);
+    color: var(--body-text);
 }
 
 .security-lock-panel h2 {
@@ -184,15 +307,16 @@ body.locked {
 }
 
 .hub-card {
-    border-radius: 0.75rem;
-    background: linear-gradient(135deg, rgba(56, 189, 248, 0.2), rgba(59, 130, 246, 0.08));
-    border: 1px solid rgba(59, 130, 246, 0.15);
+    border-radius: 0.85rem;
+    background: linear-gradient(135deg, var(--accent-strong), transparent);
+    border: 1px solid var(--border-subtle);
+    box-shadow: var(--shadow-soft);
     transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .hub-card:hover {
     transform: translateY(-2px);
-    box-shadow: 0 1rem 2rem rgba(59, 130, 246, 0.2);
+    box-shadow: var(--shadow-strong);
 }
 
 .hub-icon {
@@ -202,28 +326,29 @@ body.locked {
     width: 48px;
     height: 48px;
     border-radius: 50%;
-    background: rgba(59, 130, 246, 0.25);
-    color: #e0f2fe;
+    background: var(--accent-soft);
+    color: var(--accent);
     font-weight: 700;
 }
 
 .admin-dashboard .admin-panel {
-    background: rgba(17, 24, 39, 0.7);
+    background: var(--surface-strong);
     border-radius: 1rem;
-    border: 1px solid rgba(148, 163, 184, 0.2);
-    box-shadow: 0 2rem 4rem rgba(15, 23, 42, 0.4);
+    border: 1px solid var(--border-subtle);
+    box-shadow: var(--shadow-strong);
 }
 
 .admin-metric-card {
-    border-radius: 0.75rem;
+    border-radius: 0.85rem;
     padding: 1.25rem;
-    color: #0f172a;
     font-weight: 600;
     display: flex;
     flex-direction: column;
     justify-content: center;
     min-height: 120px;
-    background: linear-gradient(135deg, #bfdbfe, #dbeafe);
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.2), rgba(59, 130, 246, 0.05));
+    color: var(--body-text);
+    border: 1px solid transparent;
 }
 
 .admin-metric-card .admin-metric-label {
@@ -240,11 +365,11 @@ body.locked {
 }
 
 .admin-metric-card.alt {
-    background: linear-gradient(135deg, #a7f3d0, #d1fae5);
+    background: linear-gradient(135deg, rgba(16, 185, 129, 0.24), rgba(45, 212, 191, 0.12));
 }
 
 .admin-metric-card.danger {
-    background: linear-gradient(135deg, #fecaca, #fee2e2);
+    background: linear-gradient(135deg, rgba(248, 113, 113, 0.28), rgba(251, 191, 36, 0.16));
 }
 
 .admin-table-wrapper {
@@ -271,15 +396,15 @@ body.locked {
     padding: 0.35rem 0.75rem;
     border-radius: 999px;
     font-size: 0.85rem;
-    background: rgba(59, 130, 246, 0.15);
-    color: #dbeafe;
+    background: var(--accent-soft);
+    color: var(--accent);
 }
 
 .call-video-wrapper {
-    background: rgba(15, 23, 42, 0.5);
-    border: 1px solid rgba(148, 163, 184, 0.2);
-    border-radius: 0.75rem;
-    padding: 1rem;
+    background: var(--surface);
+    border: 1px solid var(--border-subtle);
+    border-radius: 0.85rem;
+    padding: 1.1rem;
 }
 
 .call-video-grid {
@@ -295,12 +420,42 @@ body.locked {
 
 .call-video {
     width: 100%;
-    background: rgba(30, 41, 59, 0.8);
-    border-radius: 0.75rem;
+    background: var(--surface-muted);
+    border-radius: 0.85rem;
     min-height: 180px;
     object-fit: cover;
 }
 
 .modal .modal-body p {
     font-size: 0.95rem;
+}
+
+@media (max-width: 767.98px) {
+    #chat-box {
+        height: auto;
+        max-height: 55vh;
+    }
+
+    .chat-composer {
+        padding: 0.75rem;
+    }
+
+    .call-toolbar .btn {
+        min-width: 100px;
+    }
+}
+
+@media (max-width: 575.98px) {
+    header .navbar-brand {
+        font-size: 1.05rem;
+    }
+
+    #chat-box {
+        padding: 1rem;
+    }
+
+    .theme-toggle {
+        min-height: 36px;
+        min-width: 40px;
+    }
 }

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en", data-bs-theme="dark">
+<html lang="en" data-theme="dark" data-bs-theme="dark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -10,6 +10,22 @@
 
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+
+    <script>
+        (function () {
+            var theme = "light";
+            try {
+                var storageKey = "chatterbox-theme";
+                var prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)");
+                var savedTheme = window.localStorage ? window.localStorage.getItem(storageKey) : null;
+                theme = savedTheme || (prefersDark && prefersDark.matches ? "dark" : "light");
+            } catch (error) {
+                console.warn("Unable to determine theme preference before load.", error);
+            }
+            document.documentElement.setAttribute("data-theme", theme);
+            document.documentElement.setAttribute("data-bs-theme", theme);
+        })();
+    </script>
 
     <!-- CSS -->
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
@@ -27,10 +43,10 @@
 
 
 <body data-lock-timeout="{{ lock_timeout_minutes if session.get('user_id') else 0 }}" data-has-pin="{{ 1 if current_user_profile and current_user_profile.has_pin else 0 }}">
-    <header>
+    <header class="shadow-sm">
         <!-- Navbar -->
-        <nav class="navbar navbar-expand-lg bg-body-tertiary">
-            <div class="container-fluid">
+        <nav class="navbar navbar-expand-lg bg-body-tertiary py-3">
+            <div class="container-xl">
                 <!-- Logo -->
                 <a class="navbar-brand" href="{{ url_for('home') }}">
                     <img src="/static/logo.png" width="30" height="30" alt="">
@@ -43,7 +59,7 @@
                 </button>
                 <!-- Navbar items -->
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                    <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                    <ul class="navbar-nav me-auto mb-3 mb-lg-0">
                         <!-- Chat-->
                         <li class="nav-item">
                             <a class="nav-link" aria-current="page" href="{{ url_for('chat') }}">Chat</a>
@@ -59,24 +75,28 @@
                         {% endif %}
                     </ul>
                     <!-- Login/Register/Logout -->
-                    <div class="d-flex">
+                    <div class="d-flex align-items-center gap-2 flex-wrap justify-content-end">
+                        <button type="button" class="btn btn-outline-secondary theme-toggle" data-theme-toggle aria-label="Toggle theme">
+                            <span class="theme-icon theme-icon-light" aria-hidden="true">🌞</span>
+                            <span class="theme-icon theme-icon-dark" aria-hidden="true">🌙</span>
+                        </button>
                         <!-- If user is logged in -->
                         {% if session.get("user_id") %}
-                            <div class="d-flex flex-column text-end me-3">
+                            <div class="d-flex flex-column text-end">
                                 <span class="navbar-text">Welcome, {{ session["username"] }}</span>
                                 <div class="progress-info mt-1">
                                     <span class="badge text-bg-info" id="progress-level">Level {{ current_user_profile.level if current_user_profile else 1 }}</span>
                                     <span class="badge text-bg-warning text-dark" id="progress-badge">{{ current_user_profile.badge if current_user_profile else 'Newcomer' }}</span>
                                 </div>
                             </div>
-                            <button type="button" class="btn btn-outline-success mx-1" data-bs-toggle="modal" data-bs-target="#pinModal">Security</button>
-                            <a href="{{ url_for('logout') }}" class="btn btn-outline-primary mx-1">Logout</a>
+                            <button type="button" class="btn btn-outline-success" data-bs-toggle="modal" data-bs-target="#pinModal">Security</button>
+                            <a href="{{ url_for('logout') }}" class="btn btn-outline-primary">Logout</a>
                         <!-- If user is not logged in -->
                         {% else %}
-                            <a href="{{ url_for('login') }}" class="btn btn-outline-primary mx-1">Login</a>
-                            <a href="{{ url_for('register') }}" class="btn btn-outline-primary mx-1">Register</a>
+                            <a href="{{ url_for('login') }}" class="btn btn-outline-primary">Login</a>
+                            <a href="{{ url_for('register') }}" class="btn btn-outline-primary">Register</a>
                         {% endif %}
-                    </div> 
+                    </div>
                 </div>
             </div>
         </nav>
@@ -86,7 +106,7 @@
         <!-- Flash messages -->
         {% with messages = get_flashed_messages() %}
             {% if messages %}
-            <div class="container my-5">
+            <div class="container-xl my-4 my-lg-5">
                 {% for message in messages %}
                 <div class="alert alert-primary alert-dismissible fade show" role="alert">
                     {{ message }}
@@ -98,16 +118,16 @@
         {% endwith %}
 
         <!-- Main content -->
-        <div class="container my-5 text-center">
+        <div class="container-xl my-4 my-lg-5 text-center">
             {% block main %}{% endblock %}
         </div>
     </main>
 
     <footer>
         <!-- Footer -->
-        <div class="container text-center">
-            <p class="mb-0">Chatterbox &copy; 2024</p>
-            <p>
+        <div class="container-xl text-center py-4 small text-muted">
+            <p class="mb-1">Chatterbox &copy; 2024</p>
+            <p class="mb-0">
                 <a href="https://github.com/FilipRokita/chatterbox" target="_blank" class="no-underline">SOURCE CODE</a> |
                 <a href="https://raw.githubusercontent.com/FilipRokita/chatterbox/refs/heads/main/LICENSE" target="_blank" class="no-underline">LICENSE</a>
             </p>


### PR DESCRIPTION
## Summary
- add a persistent light/dark theme toggle with system preference fallbacks
- refresh the global layout spacing and footer/header presentation for better responsiveness
- update styling utilities to use CSS variables for smoother transitions across widgets

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f323c4ab60832b9186ed194cfd66f7